### PR TITLE
Adjust arrow position in right to left alignment

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - SnapKit (4.2.0)
-  - SwiftyMenu (0.6.1):
+  - SwiftyMenu (0.6.2):
     - SnapKit (~> 4.2.0)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
-  SwiftyMenu: 1c79d544140796923d28a380c2372b70430d6740
+  SwiftyMenu: 039a1fe10f32cf91abb9257c63663721abb0140b
 
 PODFILE CHECKSUM: e76fbe8ebeca450e6d7f72e5036d5d85d327d6d2
 

--- a/Example/SwiftyMenu.xcodeproj/project.pbxproj
+++ b/Example/SwiftyMenu.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Original;
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {

--- a/Example/SwiftyMenu.xcodeproj/xcshareddata/xcschemes/SwiftyMenu-Example.xcscheme
+++ b/Example/SwiftyMenu.xcodeproj/xcshareddata/xcschemes/SwiftyMenu-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/SwiftyMenu.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/SwiftyMenu.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>BuildSystemType</key>
-	<string>Original</string>
+	<string>Latest</string>
 	<key>PreviewsEnabled</key>
 	<false/>
 </dict>

--- a/Example/SwiftyMenu/AppDelegate.swift
+++ b/Example/SwiftyMenu/AppDelegate.swift
@@ -16,6 +16,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        
+        // to test right to left alignment
+//        UIView.appearance().semanticContentAttribute = .forceRightToLeft
+        
         return true
     }
 

--- a/SwiftyMenu/Classes/SwiftyMenu.swift
+++ b/SwiftyMenu/Classes/SwiftyMenu.swift
@@ -324,7 +324,11 @@ extension SwiftyMenu {
     
     private func setupArrowImage() {
         let spacing = self.selectButton.frame.width - 20 // the amount of spacing to appear between image and title
-        selectButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: CGFloat(spacing), bottom: 0, right: 0)
+        var imageEdgeInsets = UIEdgeInsets(top: 0, left: CGFloat(spacing), bottom: 0, right: 0)
+        if UIView.userInterfaceLayoutDirection(for: selectButton.semanticContentAttribute) == .rightToLeft {
+            imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: CGFloat(spacing))
+        }
+        selectButton.imageEdgeInsets = imageEdgeInsets
     }
     
     private func setupView() {


### PR DESCRIPTION
When change alignment to RTL, arrow image stay in same position, so it need to be in left.