### PR TITLE
Fix a crash when using with SPM for the default arrow image 

### DIFF
--- a/SwiftyMenu/Classes/MenuAttributes/SwiftyMenuAttributes+ArrowStyle.swift
+++ b/SwiftyMenu/Classes/MenuAttributes/SwiftyMenuAttributes+ArrowStyle.swift
@@ -36,7 +36,7 @@ public extension SwiftyMenuAttributes {
 
         var arrowStyleValues: (isEnabled: Bool, image: UIImage?) {
             let frameworkBundle = Bundle(for: SwiftyMenu.self)
-            let defaultImage = UIImage(named: "downArrow", in: frameworkBundle, compatibleWith: nil)!
+            let defaultImage = UIImage(named: "downArrow", in: frameworkBundle, compatibleWith: nil) ?? UIImage()
 
             switch self {
             case let .value(isEnabled, image):


### PR DESCRIPTION
Fix a crash when using with SPM, it give an error as its force unwrapped the UIImage variable 